### PR TITLE
 Fixed call to mb_convert_encoding if mb_detect_encoding fails

### DIFF
--- a/src/PdfDocument.php
+++ b/src/PdfDocument.php
@@ -1143,7 +1143,11 @@ class PdfDocument
                         if (extension_loaded('mbstring') === true) {
                             $detected = mb_detect_encoding($value);
                             if ($detected !== 'ASCII') {
-                                $value = chr(254) . chr(255) . mb_convert_encoding($value, 'UTF-16', $detected);
+                                if (false === $detected) { // do not provide the failed detected encoding
+                                    $value = chr(254) . chr(255) . mb_convert_encoding($value, 'UTF-16');
+                                } else {
+                                    $value = chr(254) . chr(255) . mb_convert_encoding($value, 'UTF-16', $detected);
+                                }
                             }
                         }
                         $docInfo->$key = new InternalType\StringObject((string)$value);

--- a/test/PdfDocumentTest.php
+++ b/test/PdfDocumentTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @package   LaminasPdf
+ */
+
+namespace LaminasPdfTest;
+
+use LaminasPdf as Pdf;
+
+/** \LaminasPdf\Page */
+
+/** PHPUnit Test Case */
+
+/**
+ * @category   Zend
+ * @package    LaminasPdf
+ * @subpackage UnitTests
+ * @group      LaminasPdf
+ */
+class PdfDocumentTest extends \PHPUnit\Framework\TestCase
+{
+    public function testRenderInvalidEncoding()
+    {
+        $pdf = new Pdf\PdfDocument();
+
+        $pdf->properties['Creator'] = "\xf8make_mb_detect_encoding_fail";
+
+        $resource = tmpfile();
+
+        $string = $pdf->render(false, $resource);
+        $this->assertIsString(
+            $string,
+            'Render should return a valid string'
+        );
+    }
+}


### PR DESCRIPTION
When mb_detect_encoding fails providing the result (false) to mb_convert_encoding results in this warning:

`mb_convert_encoding(): Illegal character encoding specified`

See test LaminasPdfTest\PdfDocumentTest::testRenderInvalidEncoding
