### PR TITLE
php8 changes to IndirectObjectReference.php

### DIFF
--- a/src/BinaryParser/AbstractBinaryParser.php
+++ b/src/BinaryParser/AbstractBinaryParser.php
@@ -425,7 +425,7 @@ abstract class AbstractBinaryParser
         if ($characterSet == 'MacRoman') {
             return $bytes;
         }
-        return iconv('MacRoman', $characterSet, $bytes);
+        return iconv('macintosh', $characterSet, $bytes);
     }
 
     /**

--- a/src/InternalType/IndirectObjectReference.php
+++ b/src/InternalType/IndirectObjectReference.php
@@ -74,7 +74,7 @@ class IndirectObjectReference extends AbstractTypeObject
      * @throws \LaminasPdf\Exception\ExceptionInterface
      */
     public function __construct($objNum,
-                                $genNum = 0,
+                                $genNum,
                                 IndirectObjectReference\Context $context,
                                 Pdf\ObjectFactory $factory)
     {


### PR DESCRIPTION
Fixed for PHP 8 - required parameters after optional parameters in function/method no longer allowed