### PR TITLE
Changed Font Embedding options to reflect Zf1

### DIFF
--- a/src/BinaryParser/Font/OpenType/AbstractOpenType.php
+++ b/src/BinaryParser/Font/OpenType/AbstractOpenType.php
@@ -577,6 +577,17 @@ abstract class AbstractOpenType extends Pdf\BinaryParser\Font\AbstractFont
              * outlines from fonts yet, so this means no embed.
              */
             $this->isEmbeddable = false;
+        } elseif ($this->isBitSet(2, $embeddingFlags)
+                || $this->isBitSet(3, $embeddingFlags)
+                || $this->isBitSet(4, $embeddingFlags)
+            ) {
+            /* One of:
+            *     Restricted License embedding (0x0002)
+            *     Preview & Print embedding (0x0004)
+            *     Editable embedding (0x0008)
+            * is set.  This was in Zf1/Pdf but was removed in Zf2/Laminas ...
+            */
+            $this->isEmbeddable = true;
         } elseif ($this->isBitSet(1, $embeddingFlags)) {
             /* Restricted license embedding. We currently don't have any way to
              * enforce this, so interpret this as no embed. This may be revised


### PR DESCRIPTION
We are migrating from Original Zend_Pdf (version minimal 1.12.5) and need this put back in as some fonts don't get embedded as they originally did.  This only seems to affect Adobe Pdf viewers and not Foxit/Phantom.  It was omitted when migrating Zf1 to Zend2 - happy to understand why but need it back in until can manage to find a workaround.  

Copied the missing lines directly from the ZendFramework-1.12.5  library - but yeah - my bad we should have migrated from this years ago!