### PR TITLE
consolidate to monospace

### DIFF
--- a/src/BinaryParser/Font/OpenType/AbstractOpenType.php
+++ b/src/BinaryParser/Font/OpenType/AbstractOpenType.php
@@ -385,7 +385,7 @@ abstract class AbstractOpenType extends Pdf\BinaryParser\Font\AbstractFont
         $this->underlineThickness = $this->readInt(2);
 
         $fixedPitch = $this->readUInt(4);
-        $this->isMonospaced = ($fixedPitch !== 0);
+        $this->isMonospace = ($fixedPitch !== 0);
 
         /* Skip over PostScript virtual memory usage.
          */

--- a/src/Resource/Font/CidFont/AbstractCidFont.php
+++ b/src/Resource/Font/CidFont/AbstractCidFont.php
@@ -82,7 +82,7 @@ abstract class AbstractCidFont extends FontResource\AbstractFont
 
         $this->_isBold = $fontParser->isBold;
         $this->_isItalic = $fontParser->isItalic;
-        $this->_isMonospaced = $fontParser->isMonospaced;
+        $this->_isMonospace = $fontParser->isMonospace;
 
         $this->_underlinePosition = $fontParser->underlinePosition;
         $this->_underlineThickness = $fontParser->underlineThickness;

--- a/src/Resource/Font/FontDescriptor.php
+++ b/src/Resource/Font/FontDescriptor.php
@@ -77,7 +77,7 @@ class FontDescriptor
          * determined from the font parser.
          */
         $flags = 0;
-        if ($fontParser->isMonospaced) {    // bit 1: FixedPitch
+        if ($fontParser->isMonospace) {    // bit 1: FixedPitch
             $flags |= 1 << 0;
         }
         if ($fontParser->isSerifFont) {    // bit 2: Serif

--- a/src/Resource/Font/Simple/Parsed/AbstractParsed.php
+++ b/src/Resource/Font/Simple/Parsed/AbstractParsed.php
@@ -44,7 +44,7 @@ abstract class AbstractParsed extends \LaminasPdf\Resource\Font\Simple\AbstractS
 
         $this->_isBold = $fontParser->isBold;
         $this->_isItalic = $fontParser->isItalic;
-        $this->_isMonospaced = $fontParser->isMonospaced;
+        $this->_isMonospace = $fontParser->isMonospace;
 
         $this->_underlinePosition = $fontParser->underlinePosition;
         $this->_underlineThickness = $fontParser->underlineThickness;

--- a/src/Resource/Font/Simple/Standard/Courier.php
+++ b/src/Resource/Font/Simple/Standard/Courier.php
@@ -81,7 +81,7 @@ class Courier extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/CourierBold.php
+++ b/src/Resource/Font/Simple/Standard/CourierBold.php
@@ -82,7 +82,7 @@ class CourierBold extends AbstractStandard
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/CourierBoldOblique.php
+++ b/src/Resource/Font/Simple/Standard/CourierBoldOblique.php
@@ -83,7 +83,7 @@ class CourierBoldOblique extends AbstractStandard
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/CourierOblique.php
+++ b/src/Resource/Font/Simple/Standard/CourierOblique.php
@@ -83,7 +83,7 @@ class CourierOblique extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = true;
+        $this->_isMonospace = true;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/Helvetica.php
+++ b/src/Resource/Font/Simple/Standard/Helvetica.php
@@ -91,7 +91,7 @@ class Helvetica extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/HelveticaBold.php
+++ b/src/Resource/Font/Simple/Standard/HelveticaBold.php
@@ -92,7 +92,7 @@ class HelveticaBold extends AbstractStandard
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
+++ b/src/Resource/Font/Simple/Standard/HelveticaBoldOblique.php
@@ -94,7 +94,7 @@ class HelveticaBoldOblique extends AbstractStandard
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/HelveticaOblique.php
+++ b/src/Resource/Font/Simple/Standard/HelveticaOblique.php
@@ -93,7 +93,7 @@ class HelveticaOblique extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/Symbol.php
+++ b/src/Resource/Font/Simple/Standard/Symbol.php
@@ -98,7 +98,7 @@ class Symbol extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/TimesBold.php
+++ b/src/Resource/Font/Simple/Standard/TimesBold.php
@@ -90,7 +90,7 @@ class TimesBold extends AbstractStandard
 
         $this->_isBold = true;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/TimesBoldItalic.php
+++ b/src/Resource/Font/Simple/Standard/TimesBoldItalic.php
@@ -91,7 +91,7 @@ class TimesBoldItalic extends AbstractStandard
 
         $this->_isBold = true;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/TimesItalic.php
+++ b/src/Resource/Font/Simple/Standard/TimesItalic.php
@@ -91,7 +91,7 @@ class TimesItalic extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = true;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/TimesRoman.php
+++ b/src/Resource/Font/Simple/Standard/TimesRoman.php
@@ -91,7 +91,7 @@ class TimesRoman extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Simple/Standard/ZapfDingbats.php
+++ b/src/Resource/Font/Simple/Standard/ZapfDingbats.php
@@ -111,7 +111,7 @@ class ZapfDingbats extends AbstractStandard
 
         $this->_isBold = false;
         $this->_isItalic = false;
-        $this->_isMonospaced = false;
+        $this->_isMonospace = false;
 
         $this->_underlinePosition = -100;
         $this->_underlineThickness = 50;

--- a/src/Resource/Font/Type0.php
+++ b/src/Resource/Font/Type0.php
@@ -101,7 +101,7 @@ class Type0 extends AbstractFont
 
         $this->_isBold = $descendantFont->isBold();
         $this->_isItalic = $descendantFont->isItalic();
-        $this->_isMonospaced = $descendantFont->isMonospace();
+        $this->_isMonospace = $descendantFont->isMonospace();
 
         $this->_underlinePosition = $descendantFont->getUnderlinePosition();
         $this->_underlineThickness = $descendantFont->getUnderlineThickness();


### PR DESCRIPTION
There are mixed usages of `isMonospace` vs `isMonospaced` which results in the following warning on PHP 8.2.12

```
Deprecated: Creation of dynamic property LaminasPdf\Resource\Font\Simple\Standard\TimesRoman::$_isMonospaced is deprecated in D:\XXX\vendor\nmiles\laminas-pdf\src\Resource\Font\Simple\Standard\TimesRoman.php on line 94
```