### PR TITLE
add missing _pdfHeaderVersion property

### DIFF
--- a/src/PdfDocument.php
+++ b/src/PdfDocument.php
@@ -146,6 +146,13 @@ class PdfDocument
      */
     protected $_parser;
 
+    /**
+     * PDF Version number.
+     * 
+     * @var string
+     */
+    protected $_pdfHeaderVersion;
+
 
     /**
      * List of inheritable attributesfor pages tree


### PR DESCRIPTION
Otherwise I get this warning on PHP 8.2.12

```
Deprecated: Creation of dynamic property LaminasPdf\PdfDocument::$_pdfHeaderVersion is deprecated in D:\XXX\vendor\nmiles\laminas-pdf\src\PdfDocument.php on line 291
```

It is only written to but never read.